### PR TITLE
Added ITickable interface, Aquarium.tick only ticks ITickable objects

### DIFF
--- a/src/main/java/com/grupp26/aquasim/model/Aquarium.java
+++ b/src/main/java/com/grupp26/aquasim/model/Aquarium.java
@@ -47,12 +47,11 @@ public class Aquarium implements IAquarium {
         for (IFish fish : fishList) {
             fish.tick();
         }
-        // decorations not tickabe (yet)
-        // Add tickable inteface?
-        // iterate trhough tickable or check each if tickable
-        // for (IDecoration decoration : decorationList) {
-        // decoration.tick();
-        // }
+        for (IDecoration decoration : decorationList) {
+            if (decoration instanceof ITickable tickDeco) {
+                tickDeco.tick();
+            }
+        }
     }
     
     @Override

--- a/src/main/java/com/grupp26/aquasim/model/IFish.java
+++ b/src/main/java/com/grupp26/aquasim/model/IFish.java
@@ -1,6 +1,6 @@
 package com.grupp26.aquasim.model;
 
-public interface IFish {
+public interface IFish extends ITickable {
     // comment = private attributes
     // has the following
     // int age;
@@ -29,7 +29,5 @@ public interface IFish {
     Vec3<Integer> getPos();
 
     void setPos(int x, int y, int z);
-
-    void tick();
 
 }

--- a/src/main/java/com/grupp26/aquasim/model/ITickable.java
+++ b/src/main/java/com/grupp26/aquasim/model/ITickable.java
@@ -1,0 +1,5 @@
+package com.grupp26.aquasim.model;
+
+public interface ITickable {
+    void tick();
+}


### PR DESCRIPTION
#49
- Added ITickable Interface.
- Removed tick() from IFish but made IFish extend ITickable since all fish need to be tickable.
- Aquarium.tick() now also ticks all IDecorations that are ITickable.

Notes:
Decided not to create a new ArrayList<ITickable> in Aquarium since that would just be duplicate objects already in fishList or decoList.
Did not make food tickable, assuming we will?
Did not IAquarium tickable even though it has a tick method

